### PR TITLE
Enforces bandwidth limit on portable access point

### DIFF
--- a/server/BandwidthController.cpp
+++ b/server/BandwidthController.cpp
@@ -692,6 +692,13 @@ int BandwidthController::prepCostlyIface(const char *ifn, QuotaType quotaType) {
 
     snprintf(cmd, sizeof(cmd), "-I bw_OUTPUT %d -o %s --jump %s", ruleInsertPos, ifn, costCString);
     res |= runIpxtablesCmd(cmd, IptJumpNoAdd);
+
+    snprintf(cmd, sizeof(cmd), "-D bw_FORWARD -i %s --jump %s", ifn, costCString);
+    runIpxtablesCmd(cmd, IptJumpNoAdd, IptFailHide);
+
+    snprintf(cmd, sizeof(cmd), "-I bw_FORWARD %d -i %s --jump %s", ruleInsertPos, ifn, costCString);
+    res |= runIpxtablesCmd(cmd, IptJumpNoAdd);
+
     return res;
 }
 


### PR DESCRIPTION
If user sets a bandwith limit for cellular data, we need to enforce
that limit on portable access point as well.

Change-Id: I8a82a11626ceb3264be9f24e52e472d2f37d315f
TICKET: CYNGNOS-3157
